### PR TITLE
Update to new makefile executable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ Some examples of input.dat files are available in the `examples` folder.
 
 To run a simulation, type, e.g.:
 ```
-mpirun -np 8 ./streams
+mpirun -np 8 ./streams.exe
 ```
 or (for SLURM jobs)
 ```
-srun ./streams
+srun ./streams.exe
 ```
 
 For CUDA versions in cluster environments, you must distribute MPI processes according to the number of GPUs 
@@ -92,7 +92,7 @@ available for each node. For CINECA Marconi-100 cluster -- 4 GPUS per node --  a
 
 module load profile/global hpc-sdk/20.5--binary
 
-mpirun -np 8 ./streams
+mpirun -np 8 ./streams.exe
 ```
 
 For CSCS Pitz-Daint cluster -- 1 GPU per node -- a possible submission script using 8 GPUs is:
@@ -106,7 +106,7 @@ For CSCS Pitz-Daint cluster -- 1 GPU per node -- a possible submission script us
 #SBATCH --gres=gpu:1
 #SBATCH --constraint=gpu 
 module swap PrgEnv-cray PrgEnv-pgi
-srun ./streams
+srun ./streams.exe
 ```
 
 # Preparing input.dat file


### PR DESCRIPTION
In `4b07c4a83aeaf3e53e62d149948dc00a26ea24a4` (July 30th)  the name of the executable was changed https://github.com/matteobernardini/STREAmS/commit/4b07c4a83aeaf3e53e62d149948dc00a26ea24a4?branch=4b07c4a83aeaf3e53e62d149948dc00a26ea24a4&diff=unified#diff-3e2513390df543315686d7c85bd901ca9256268970032298815d2f893a9f0685L103-R110. 

This change was not reflected in `README.md`, making the documentation out of date and the example commands errors. I have updated the readme to the new name